### PR TITLE
Change to com.theguardian

### DIFF
--- a/newsroom/src/androidTest/java/com/theguardian/newsroom/ExampleInstrumentedTest.kt
+++ b/newsroom/src/androidTest/java/com/theguardian/newsroom/ExampleInstrumentedTest.kt
@@ -1,4 +1,4 @@
-package com.guardian.newsroom
+package com.theguardian.newsroom
 
 import android.support.test.InstrumentationRegistry
 import android.support.test.runner.AndroidJUnit4

--- a/newsroom/src/main/AndroidManifest.xml
+++ b/newsroom/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.guardian.newsroom">
+    package="com.theguardian.newsroom">
 
     <application
         android:allowBackup="true"

--- a/newsroom/src/main/java/com/theguardian/newsroom/Newsroom.kt
+++ b/newsroom/src/main/java/com/theguardian/newsroom/Newsroom.kt
@@ -1,4 +1,4 @@
-package com.guardian.newsroom
+package com.theguardian.newsroom
 
 import android.app.NotificationChannel
 import android.app.NotificationManager

--- a/newsroom/src/test/java/com/theguardian/newsroom/ExampleUnitTest.kt
+++ b/newsroom/src/test/java/com/theguardian/newsroom/ExampleUnitTest.kt
@@ -1,4 +1,4 @@
-package com.guardian.newsroom
+package com.theguardian.newsroom
 
 import org.junit.Test
 


### PR DESCRIPTION
This is something that always bugged me about the main project, [guardian.com](http://guardian.com) belongs to someone else :(