### PR TITLE
Retrieve Data from Room in Newsroom Activity

### DIFF
--- a/newsroom-lib/build.gradle
+++ b/newsroom-lib/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation 'com.android.support:recyclerview-v7:28.0.0-rc01'
     implementation 'io.reactivex.rxjava2:rxjava:2.1.15'
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
 
     implementation "android.arch.persistence.room:runtime:1.1.1"
     implementation 'android.arch.lifecycle:extensions:1.1.1'

--- a/newsroom-lib/build.gradle
+++ b/newsroom-lib/build.gradle
@@ -37,7 +37,9 @@ dependencies {
     implementation 'com.android.support:recyclerview-v7:28.0.0-rc01'
     implementation 'io.reactivex.rxjava2:rxjava:2.1.15'
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'
+
     implementation "android.arch.persistence.room:runtime:1.1.1"
+    implementation 'android.arch.lifecycle:extensions:1.1.1'
 
     kapt "android.arch.persistence.room:compiler:1.1.1"
 

--- a/newsroom-lib/src/main/AndroidManifest.xml
+++ b/newsroom-lib/src/main/AndroidManifest.xml
@@ -4,7 +4,9 @@
 
     <application>
 
-        <activity android:label="@string/lib_name" android:name=".ui.MainActivity" android:launchMode="singleTop">
+        <activity
+            android:label="@string/lib_name"
+            android:name=".ui.MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/newsroom-lib/src/main/AndroidManifest.xml
+++ b/newsroom-lib/src/main/AndroidManifest.xml
@@ -4,7 +4,12 @@
 
     <application>
 
-        <activity android:name=".ui.MainActivity" android:launchMode="singleTop"/>
+        <activity android:label="@string/lib_name" android:name=".ui.MainActivity" android:launchMode="singleTop">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
 
     </application>
 

--- a/newsroom-lib/src/main/AndroidManifest.xml
+++ b/newsroom-lib/src/main/AndroidManifest.xml
@@ -6,11 +6,15 @@
 
         <activity
             android:label="@string/lib_name"
-            android:name=".ui.MainActivity">
+            android:name=".ui.MainActivity"
+            android:taskAffinity="com.theguardian.newsroom.task">
+
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+                <action android:name=".ui.MainActivity"/>
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
         </activity>
 
     </application>

--- a/newsroom-lib/src/main/java/com/theguardian/newsroom/archive/room/NewsroomDatabase.kt
+++ b/newsroom-lib/src/main/java/com/theguardian/newsroom/archive/room/NewsroomDatabase.kt
@@ -1,9 +1,25 @@
 package com.theguardian.newsroom.archive.room
 
 import android.arch.persistence.room.Database
+import android.arch.persistence.room.Room
 import android.arch.persistence.room.RoomDatabase
+import android.content.Context
 
 @Database(entities = [RoomEvent::class], version = 1)
 abstract class NewsroomDatabase : RoomDatabase() {
     abstract fun roomEventDao(): RoomEventDao
+
+    companion object {
+
+        private var instance : NewsroomDatabase? = null
+
+        fun getInstance(context: Context): NewsroomDatabase {
+            if(instance == null){
+               instance = Room.databaseBuilder(context, NewsroomDatabase::class.java, "newsroom-db").build()
+            }
+
+            return instance as NewsroomDatabase
+        }
+
+    }
 }

--- a/newsroom-lib/src/main/java/com/theguardian/newsroom/archive/room/RoomEvent.kt
+++ b/newsroom-lib/src/main/java/com/theguardian/newsroom/archive/room/RoomEvent.kt
@@ -3,13 +3,16 @@ package com.theguardian.newsroom.archive.room
 import android.arch.persistence.room.ColumnInfo
 import android.arch.persistence.room.Entity
 import android.arch.persistence.room.PrimaryKey
+import java.util.*
 
 @Entity
 data class RoomEvent(
-        @PrimaryKey(autoGenerate = true)
+        @PrimaryKey
         var id: Long?,
         @ColumnInfo
         val source: String,
         @ColumnInfo
-        val title: String
+        val title: String,
+        @ColumnInfo
+        val timestamp: Date
 )

--- a/newsroom-lib/src/main/java/com/theguardian/newsroom/archive/room/RoomEvent.kt
+++ b/newsroom-lib/src/main/java/com/theguardian/newsroom/archive/room/RoomEvent.kt
@@ -3,7 +3,6 @@ package com.theguardian.newsroom.archive.room
 import android.arch.persistence.room.ColumnInfo
 import android.arch.persistence.room.Entity
 import android.arch.persistence.room.PrimaryKey
-import java.util.*
 
 @Entity
 data class RoomEvent(

--- a/newsroom-lib/src/main/java/com/theguardian/newsroom/archive/room/RoomEvent.kt
+++ b/newsroom-lib/src/main/java/com/theguardian/newsroom/archive/room/RoomEvent.kt
@@ -14,5 +14,5 @@ data class RoomEvent(
         @ColumnInfo
         val title: String,
         @ColumnInfo
-        val timestamp: Date
+        val timestamp: Long
 )

--- a/newsroom-lib/src/main/java/com/theguardian/newsroom/archive/room/RoomEventDao.kt
+++ b/newsroom-lib/src/main/java/com/theguardian/newsroom/archive/room/RoomEventDao.kt
@@ -1,5 +1,6 @@
 package com.theguardian.newsroom.archive.room
 
+import android.arch.lifecycle.LiveData
 import android.arch.persistence.room.Dao
 import android.arch.persistence.room.Insert
 import android.arch.persistence.room.Query
@@ -8,7 +9,7 @@ import android.arch.persistence.room.Query
 interface RoomEventDao {
 
     @Query("SELECT * FROM RoomEvent")
-    fun getAllRoomEvents(): List<RoomEvent>
+    fun getAllRoomEvents(): LiveData<List<RoomEvent>>
 
     @Insert
     fun insert(event: RoomEvent)

--- a/newsroom-lib/src/main/java/com/theguardian/newsroom/desks/DatabaseDesk.kt
+++ b/newsroom-lib/src/main/java/com/theguardian/newsroom/desks/DatabaseDesk.kt
@@ -8,11 +8,7 @@ import com.theguardian.newsroom.model.Event
 
 class DatabaseDesk(private val context: Context) : Desk {
 
-    private val newsroomDatabase: NewsroomDatabase by lazy {
-        Room.databaseBuilder(context, NewsroomDatabase::class.java, "newsroom-db").build()
-    }
-
     override fun handleEvent(event: Event) {
-        newsroomDatabase.roomEventDao().insert(RoomEvent(event.id, event.source, event.title, event.date.time))
+        NewsroomDatabase.getInstance(context).roomEventDao().insert(RoomEvent(event.id, event.source, event.title, event.date.time))
     }
 }

--- a/newsroom-lib/src/main/java/com/theguardian/newsroom/desks/DatabaseDesk.kt
+++ b/newsroom-lib/src/main/java/com/theguardian/newsroom/desks/DatabaseDesk.kt
@@ -13,6 +13,6 @@ class DatabaseDesk(private val context: Context) : Desk {
     }
 
     override fun handleEvent(event: Event) {
-        newsroomDatabase.roomEventDao().insert(RoomEvent(null, event.source, event.title))
+        newsroomDatabase.roomEventDao().insert(RoomEvent(event.id, event.source, event.title, event.date))
     }
 }

--- a/newsroom-lib/src/main/java/com/theguardian/newsroom/ext/ViewModelExtensions.kt
+++ b/newsroom-lib/src/main/java/com/theguardian/newsroom/ext/ViewModelExtensions.kt
@@ -1,0 +1,24 @@
+package com.theguardian.newsroom.ext
+
+import android.arch.lifecycle.*
+import android.support.v4.app.FragmentActivity
+
+typealias NonNullObserver<T> = (T) -> Unit
+
+@Suppress("UNCHECKED_CAST")
+inline fun <reified T : ViewModel> FragmentActivity.getViewModel(crossinline factory: () -> T): T {
+
+    val vmFactory = object : ViewModelProvider.Factory {
+        override fun <U : ViewModel> create(modelClass: Class<U>): U = factory() as U
+    }
+
+    return ViewModelProviders.of(this, vmFactory)[T::class.java]
+}
+
+fun <T : Any, L : LiveData<T>> LifecycleOwner.observeNonNull(liveData: L, observer: NonNullObserver<T>) {
+    liveData.observe(this, Observer {
+        if (it != null) {
+            observer.invoke(it)
+        }
+    })
+}

--- a/newsroom-lib/src/main/java/com/theguardian/newsroom/model/Event.kt
+++ b/newsroom-lib/src/main/java/com/theguardian/newsroom/model/Event.kt
@@ -3,5 +3,6 @@ package com.theguardian.newsroom.model
 import java.util.*
 
 data class Event(val source: String, val title: String, val data: Map<String, String?>? = emptyMap()) {
+    val id = Random().nextLong()
     val date = Date()
 }

--- a/newsroom-lib/src/main/java/com/theguardian/newsroom/model/Event.kt
+++ b/newsroom-lib/src/main/java/com/theguardian/newsroom/model/Event.kt
@@ -2,7 +2,6 @@ package com.theguardian.newsroom.model
 
 import java.util.*
 
-data class Event(val source: String, val title: String, val data: Map<String, String?>? = emptyMap()) {
+data class Event(val source: String, val title: String, val date : Date = Date(), val data: Map<String, String?>? = emptyMap()) {
     val id = Random().nextLong()
-    val date = Date()
 }

--- a/newsroom-lib/src/main/java/com/theguardian/newsroom/reporter/Reporter.kt
+++ b/newsroom-lib/src/main/java/com/theguardian/newsroom/reporter/Reporter.kt
@@ -2,6 +2,7 @@ package com.theguardian.newsroom.reporter
 
 import com.theguardian.newsroom.Newsroom
 import com.theguardian.newsroom.model.Event
+import java.util.*
 
 abstract class Reporter(private val sourceName: String) {
     private var _newsroom: Newsroom? = null
@@ -16,7 +17,7 @@ abstract class Reporter(private val sourceName: String) {
     }
 
     fun reportEvent(title: String, data: Map<String, String?>? = emptyMap()) {
-        newsroom.reportEvent(Event(sourceName, title, data))
+        newsroom.reportEvent(Event(sourceName, title, Date(),data))
     }
 
     abstract fun onStart()

--- a/newsroom-lib/src/main/java/com/theguardian/newsroom/ui/EventDiffCallback.kt
+++ b/newsroom-lib/src/main/java/com/theguardian/newsroom/ui/EventDiffCallback.kt
@@ -1,0 +1,20 @@
+package com.theguardian.newsroom.ui
+
+import android.support.v7.util.DiffUtil
+import com.theguardian.newsroom.model.Event
+
+class EventDiffCallback(
+        private val oldUpdates: List<Event>,
+        private val newUpdates: List<Event>
+) : DiffUtil.Callback() {
+
+    override fun getOldListSize(): Int = oldUpdates.size
+
+    override fun getNewListSize(): Int = newUpdates.size
+
+    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
+            oldUpdates[oldItemPosition].id == newUpdates[newItemPosition].id
+
+    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
+            oldUpdates[oldItemPosition] == newUpdates[newItemPosition]
+}

--- a/newsroom-lib/src/main/java/com/theguardian/newsroom/ui/MainActivity.kt
+++ b/newsroom-lib/src/main/java/com/theguardian/newsroom/ui/MainActivity.kt
@@ -8,6 +8,7 @@ import com.theguardian.newsroom.ext.getViewModel
 import com.theguardian.newsroom.ext.observeNonNull
 import com.theguardian.newsroom.model.Event
 import kotlinx.android.synthetic.main.activity_main.*
+import java.util.*
 
 class MainActivity : FragmentActivity() {
 
@@ -22,10 +23,10 @@ class MainActivity : FragmentActivity() {
     }
 
     private fun initViewModel(){
-        newsroomViewModel = getViewModel { NewsroomViewModel(this) }.apply {
+        newsroomViewModel = getViewModel { NewsroomViewModel(application) }.apply {
             observeNonNull(allEvents) {
                 val events = it.map {
-                    Event(it.source, it.title, mapOf())
+                    Event(it.source, it.title, Date(it.timestamp))
                 }
 
                 adapter.setData(events)

--- a/newsroom-lib/src/main/java/com/theguardian/newsroom/ui/MainActivity.kt
+++ b/newsroom-lib/src/main/java/com/theguardian/newsroom/ui/MainActivity.kt
@@ -31,6 +31,7 @@ class MainActivity : Activity() {
     }
 
     private fun loadData(){
+        //TODO Replace with RxJava flowable so we continue to get updates
         thread {
             val events = newsroomDatabase.roomEventDao().getAllRoomEvents().map {
                 Event(it.source, it.title, mapOf())

--- a/newsroom-lib/src/main/java/com/theguardian/newsroom/ui/MainActivity.kt
+++ b/newsroom-lib/src/main/java/com/theguardian/newsroom/ui/MainActivity.kt
@@ -25,11 +25,11 @@ class MainActivity : FragmentActivity() {
     private fun initViewModel(){
         newsroomViewModel = getViewModel { NewsroomViewModel(application) }.apply {
             observeNonNull(allEvents) {
-                val events = it.map {
+                it.map {
                     Event(it.source, it.title, Date(it.timestamp))
+                }.apply {
+                    adapter.setData(this)
                 }
-
-                adapter.setData(events)
             }
         }
     }

--- a/newsroom-lib/src/main/java/com/theguardian/newsroom/ui/MainActivity.kt
+++ b/newsroom-lib/src/main/java/com/theguardian/newsroom/ui/MainActivity.kt
@@ -1,26 +1,41 @@
 package com.theguardian.newsroom.ui
 
 import android.app.Activity
+import android.arch.persistence.room.Room
 import android.os.Bundle
 import android.support.v7.widget.LinearLayoutManager
-import com.theguardian.newsroom.Newsroom
 import com.theguardian.newsroom.R
-import com.theguardian.newsroom.reporter.GoogleAnalyticsReporter
+import com.theguardian.newsroom.archive.room.NewsroomDatabase
+import com.theguardian.newsroom.model.Event
 import kotlinx.android.synthetic.main.activity_main.*
+import kotlin.concurrent.thread
 
 class MainActivity : Activity() {
+
+    private val adapter = ReportedEventAdapter()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
         initRecyclerView()
+        loadData()
+    }
 
-        Newsroom(this).addReporter(GoogleAnalyticsReporter())
+    private val newsroomDatabase: NewsroomDatabase by lazy {
+        Room.databaseBuilder(this, NewsroomDatabase::class.java, "newsroom-db").build()
     }
 
     private fun initRecyclerView() {
-        val adapter = ReportedEventAdapter(emptyList())
         rvReportedEvents.adapter = adapter
         rvReportedEvents.layoutManager = LinearLayoutManager(this)
+    }
+
+    private fun loadData(){
+        thread {
+            val events = newsroomDatabase.roomEventDao().getAllRoomEvents().map {
+                Event(it.source, it.title, mapOf())
+            }
+            adapter.setData(events)
+        }
     }
 }

--- a/newsroom-lib/src/main/java/com/theguardian/newsroom/ui/NewsroomViewModel.kt
+++ b/newsroom-lib/src/main/java/com/theguardian/newsroom/ui/NewsroomViewModel.kt
@@ -1,18 +1,21 @@
-package com.theguardian.newsroom.desks
+package com.theguardian.newsroom.ui
 
+import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.ViewModel
 import android.arch.persistence.room.Room
 import android.content.Context
 import com.theguardian.newsroom.archive.room.NewsroomDatabase
 import com.theguardian.newsroom.archive.room.RoomEvent
-import com.theguardian.newsroom.model.Event
 
-class DatabaseDesk(private val context: Context) : Desk {
+class NewsroomViewModel(context: Context) : ViewModel() {
+
+    val allEvents: LiveData<List<RoomEvent>>
 
     private val newsroomDatabase: NewsroomDatabase by lazy {
         Room.databaseBuilder(context, NewsroomDatabase::class.java, "newsroom-db").build()
     }
 
-    override fun handleEvent(event: Event) {
-        newsroomDatabase.roomEventDao().insert(RoomEvent(event.id, event.source, event.title, event.date.time))
+    init {
+        allEvents = newsroomDatabase.roomEventDao().getAllRoomEvents()
     }
 }

--- a/newsroom-lib/src/main/java/com/theguardian/newsroom/ui/NewsroomViewModel.kt
+++ b/newsroom-lib/src/main/java/com/theguardian/newsroom/ui/NewsroomViewModel.kt
@@ -1,21 +1,11 @@
 package com.theguardian.newsroom.ui
 
-import android.arch.lifecycle.LiveData
-import android.arch.lifecycle.ViewModel
-import android.arch.persistence.room.Room
-import android.content.Context
+import android.app.Application
+import android.arch.lifecycle.AndroidViewModel
 import com.theguardian.newsroom.archive.room.NewsroomDatabase
-import com.theguardian.newsroom.archive.room.RoomEvent
 
-class NewsroomViewModel(context: Context) : ViewModel() {
+class NewsroomViewModel(application: Application) : AndroidViewModel(application) {
 
-    val allEvents: LiveData<List<RoomEvent>>
+    val allEvents = NewsroomDatabase.getInstance(application).roomEventDao().getAllRoomEvents()
 
-    private val newsroomDatabase: NewsroomDatabase by lazy {
-        Room.databaseBuilder(context, NewsroomDatabase::class.java, "newsroom-db").build()
-    }
-
-    init {
-        allEvents = newsroomDatabase.roomEventDao().getAllRoomEvents()
-    }
 }

--- a/newsroom-lib/src/main/java/com/theguardian/newsroom/ui/ReportedEventAdapter.kt
+++ b/newsroom-lib/src/main/java/com/theguardian/newsroom/ui/ReportedEventAdapter.kt
@@ -1,5 +1,6 @@
 package com.theguardian.newsroom.ui
 
+import android.support.v7.util.DiffUtil
 import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
@@ -8,7 +9,9 @@ import android.widget.TextView
 import com.theguardian.newsroom.R
 import com.theguardian.newsroom.model.Event
 
-class ReportedEventAdapter(private val eventList: List<Event>) : RecyclerView.Adapter<ReportedEventAdapter.JsonStringViewHolder>() {
+class ReportedEventAdapter : RecyclerView.Adapter<ReportedEventAdapter.JsonStringViewHolder>() {
+
+    private var eventList: List<Event> = emptyList()
 
     override fun onCreateViewHolder(viewGroup: ViewGroup, i: Int): JsonStringViewHolder {
         val view = LayoutInflater.from(viewGroup.context).inflate(R.layout.list_item, null)
@@ -21,6 +24,12 @@ class ReportedEventAdapter(private val eventList: List<Event>) : RecyclerView.Ad
         customViewHolder.tvMessage.text = event.data?.toString()
         customViewHolder.tvSource.text = event.source
         customViewHolder.tvTimestamp.text = event.date.toString()
+    }
+
+    fun setData(eventList: List<Event>){
+        val diff = DiffUtil.calculateDiff(EventDiffCallback(this.eventList, eventList))
+        this.eventList = eventList
+        diff.dispatchUpdatesTo(this)
     }
 
     override fun getItemCount(): Int {

--- a/newsroom-lib/src/main/res/layout/list_item.xml
+++ b/newsroom-lib/src/main/res/layout/list_item.xml
@@ -11,6 +11,7 @@
         android:id="@+id/llDetails"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:background="@android:color/holo_orange_dark"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 

--- a/newsroom-lib/src/main/res/values/strings.xml
+++ b/newsroom-lib/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Newsroom</string>
+    <string name="lib_name">Newsroom</string>
 </resources>

--- a/newsroom/build.gradle
+++ b/newsroom/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-android-extensions'
 android {
     compileSdkVersion 28
     defaultConfig {
-        applicationId "com.theguardian.newsroom"
+        applicationId "com.theguardian.newsroom.sample"
         minSdkVersion 16
         targetSdkVersion 28
         versionCode 1

--- a/newsroom/src/main/AndroidManifest.xml
+++ b/newsroom/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
         <activity
             android:name=".SampleActivity"
             android:label="@string/app_name"
-            android:launchMode="singleTask"
             android:theme="@style/AppTheme">
 
             <intent-filter>

--- a/newsroom/src/main/java/com/theguardian/newsroom/sample/SampleActivity.kt
+++ b/newsroom/src/main/java/com/theguardian/newsroom/sample/SampleActivity.kt
@@ -18,7 +18,7 @@ class SampleActivity : Activity() {
 
 class TestReporter : Reporter("Test reporter") {
     override fun onStart() {
-        Observable.interval(1, TimeUnit.SECONDS).subscribe {
+        Observable.interval(5, TimeUnit.SECONDS).subscribe {
             reportEvent("Test Event", mapOf("Time" to it.toString()))
         }
     }

--- a/newsroom/src/main/res/values/strings.xml
+++ b/newsroom/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Newsroom</string>
+    <string name="app_name">Newsroom Sample</string>
 </resources>


### PR DESCRIPTION
In this PR I've implemented more of the adapter in the Newsroom Activity, as well as made the Newsroom activity appear in the Launcher.

Event's now generate their own ID's as they're used to compare them in the adapter.

---

Due to a limitation in LiveData and Room, I've had to implement a Singleton for the Newsroom Database. This isn't an ideal solution, so I think it'd be good to chat about other implementation before we go forward with this one.
